### PR TITLE
Replace FCGX_FPrintF by FCGX_PutS

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -55,6 +55,7 @@ extern {
     pub fn FCGX_Finish_r(request: *mut FCGX_Request) -> libc::c_int;
     pub fn FCGX_GetParam(name: *const libc::c_char, envp: *mut libc::c_void) -> *mut libc::c_char;
     pub fn FCGX_FPrintF(stream: *mut libc::c_void, format: *const libc::c_char) -> libc::c_int;
+    pub fn FCGX_PutS(format: *const libc::c_char, stream: *mut libc::c_void) -> libc::c_int;
     pub fn FCGX_GetStr(input: *mut libc::c_char, n: libc::c_int, stream: *mut libc::c_void) -> libc::c_int;
     pub fn FCGX_FFlush(stream: *mut libc::c_void);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,13 +145,13 @@ impl Request for DefaultRequest {
 
     fn write<T:ToCStr>(&mut self, msg: T) -> i32 {
         unsafe {
-            return ffi::FCGX_FPrintF(self.raw_request.out_stream, msg.to_c_str().as_ptr());
+            return ffi::FCGX_PutS(msg.to_c_str().as_ptr(), self.raw_request.out_stream);
         }
     }
 
     fn error<T:ToCStr>(&mut self, msg: T) -> i32 {
         unsafe {
-            return ffi::FCGX_FPrintF(self.raw_request.err_stream, msg.to_c_str().as_ptr());
+            return ffi::FCGX_PutS(msg.to_c_str().as_ptr(), self.raw_request.err_stream);
         }
     }
 


### PR DESCRIPTION
It seems your not using the FCGX_FPrintF "printf-style output" so I changed it to the more efficient function FCGX_PutS.